### PR TITLE
Add 18U rack size option

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
                 <div>
                     <label for="rackSizeSelect" class="action-label">Size</label>
                     <select id="rackSizeSelect">
+                        <option value="18">18U</option>
                         <option value="24">24U</option>
                         <option value="42" selected>42U</option>
                         <option value="48">48U</option>


### PR DESCRIPTION
## Summary
Adds 18U as a rack size option in the dropdown, supporting smaller rack configurations commonly used in network closets and small server rooms.

This serves as a proof-of-concept that the codebase already handles non-standard rack sizes gracefully - no JavaScript, Python, or rendering changes were needed.

## Changes
- Added `<option value="18">18U</option>` to the rack size dropdown in `templates/index.html`

## Testing
- [x] Create new rack with 18U size
- [x] Place equipment in 18U rack
- [x] Verify canvas rendering scales correctly
- [x] Multi-rack view handles mixed sizes

## Not Tested
- Changing rack size with equipment already installed (e.g., 24U → 18U)
- V-PDUs (full-height vertical PDUs) in 18U racks

Related to broader feature request for custom rack sizes.